### PR TITLE
Add support for INSERT OR IGNORE

### DIFF
--- a/insert_test.go
+++ b/insert_test.go
@@ -56,6 +56,12 @@ func TestInsert(t *testing.T) {
 				"INSERT INTO table (name) VALUES (?) ON CONFLICT (name, something_else) DO UPDATE SET update_date = ?, name = ?, address = ?",
 				[]interface{}{"My Name", 55151515, "My Name Again", "Some Address"},
 			},
+			test{
+				"insert or ignore",
+				dbz.InsertInto("table").OrIgnore().Columns("id", "name", "date").Values(1, "My Name", 96969696),
+				"INSERT OR IGNORE INTO table (id, name, date) VALUES (?, ?, ?)",
+				[]interface{}{1, "My Name", 96969696},
+			},
 		}
 	})
 }


### PR DESCRIPTION
This commit adds support for INSERT OR IGNORE clause,
where the specified row is already exist.
Sample usage:

        _, err = z.
            InsertInto("table").
	    OrIgnore.
            Columns("name").
            Values("My Name").
            Exec()