### PR TITLE
Add error handling to SQLz

### DIFF
--- a/statment.go
+++ b/statment.go
@@ -1,0 +1,14 @@
+package sqlz
+
+
+type Statment struct {
+	ErrHandlers []func(err error)
+}
+
+func (stmt *Statment) HandlerError(err error) {
+	if stmt.ErrHandlers != nil {
+		for _, handler := range stmt.ErrHandlers {
+			handler(err)
+		}
+	}
+}


### PR DESCRIPTION
    Currently sqlz returns the error from each query execution as is.
    This commit adds error handling: when creating new sqlz instace we can
    pass functions as variables that will be invoked after each sql execution.

    The purpose of this functions are to change the error we get from the
    sql driver (e.g mask certain messages).