### PR TITLE
Add ability to insert multiple rows

### DIFF
--- a/insert_test.go
+++ b/insert_test.go
@@ -83,6 +83,14 @@ func TestInsert(t *testing.T) {
 				"INSERT OR REPLACE INTO table (id, name, date) VALUES (?, ?, ?)",
 				[]interface{}{1, "My Name", 96969696},
 			},
+
+			test{
+				"insert with multiple values",
+				dbz.InsertInto("table").Columns("id", "name").
+					ValueMultiple([][]interface{}{{1, "My Name"}, {2, "John"}, {3, "Golang"}}),
+				"INSERT INTO table (id, name) VALUES (?, ?), (?, ?), (?, ?)",
+				[]interface{}{1, "My Name", 2, "John", 3, "Golang"},
+			},
 		}
 	})
 }


### PR DESCRIPTION
This commit adds the ability to insert multiple rows in the same insert statement.
It may be helpful in cases when trying to avoid inserting an array of objects one
by one in order to improve performance.

Sample usage:
            _, err := z.
                InsertInto("myTable").
                Columns("col1","col2","col3").
                ValueMultiple([]interface{}{
                    {"a","b","c"},
                    {"a2","b2","c2"},
                }).
                Exec()