### PR TITLE
Add table name verification

### DIFF
--- a/select.go
+++ b/select.go
@@ -371,7 +371,9 @@ func (stmt *SelectStmt) ToSQL(rebind bool) (asSQL string, bindings []interface{}
 		clauses = append(clauses, strings.Join(stmt.Columns, ", "))
 	}
 
-	clauses = append(clauses, "FROM "+stmt.Table)
+	if len(stmt.Table) > 0 {
+		clauses = append(clauses, "FROM "+stmt.Table)
+	}
 
 	for _, join := range stmt.Joins {
 		onClause, joinBindings := parseConditions(join.Conditions)


### PR DESCRIPTION
This commit adds verification for the table name in the 'toSQL' method,
this is necessary for use cases such as LATERAL where the table is not
necessary in some cases and an empty table name is used regardless
resulting in a bad SQL query.