### PR TITLE
Add support for "array_cat" function

### DIFF
--- a/update.go
+++ b/update.go
@@ -274,3 +274,12 @@ func ArrayRemove(name string, value interface{}) UpdateFunction {
 		Arguments: []interface{}{Indirect(name), value},
 	}
 }
+
+// ArrayConcat is an UpdateFunction for calling PostgreSQL's
+// array_cat function during an update.
+func ArrayConcat(name string, value interface{}) UpdateFunction {
+	return UpdateFunction{
+		Name:      "array_cat",
+		Arguments: []interface{}{Indirect(name), value},
+	}
+}


### PR DESCRIPTION
This commit contains code that adds support for the "array_cat" function
used during the update statement.
This function concatenate two arrays.