### PR TITLE
Add ILIKE ANY

### DIFF
--- a/sqlz.go
+++ b/sqlz.go
@@ -377,6 +377,11 @@ func LikeAny(arr interface{}, value interface{}) ArrayCondition {
 	return ArrayCondition{value, "LIKE", "ANY", arr}
 }
 
+// ILikeAny creates an "ILikeAny ANY" condition on an array
+func ILikeAny(arr interface{}, value interface{}) ArrayCondition {
+	return ArrayCondition{value, "ILIKE", "ANY", arr}
+}
+
 func NotLikeAll(arr interface{}, value interface{}) ArrayCondition {
 	return ArrayCondition{value, "NOT LIKE", "ALL", arr}
 }


### PR DESCRIPTION
This commit adds the ability to use ILIKE ANY to find case-insensitive values.

Example: q.Where(
	sqlz.LikeAny(mySlice,sqlz.Indirect("myColumn")),
)